### PR TITLE
Use a dictionary to speed up RszInstanceList.IndexOf

### DIFF
--- a/RszTool/EnumParser.cs
+++ b/RszTool/EnumParser.cs
@@ -21,6 +21,16 @@ namespace RszTool
 
         public EnumDict EnumDict { get; }
 
+        public static EnumParser FromJson(string json)
+        {
+            return new EnumParser(new EnumDict(JsonSerializer.Deserialize<Dictionary<string, EnumData>>(json) ?? []));
+        }
+
+        public EnumParser(EnumDict enumDict)
+        {
+            EnumDict = enumDict;
+        }
+
         public EnumParser(string jsonPath)
         {
             if (File.Exists(jsonPath))

--- a/RszTool/RszFile/PfbFile.cs
+++ b/RszTool/RszFile/PfbFile.cs
@@ -113,7 +113,17 @@ namespace RszTool
                 set => parentRef = value != null ? new(value) : null;
             }
 
-            public string? Name => (Instance?.GetFieldValue("v0") ?? Instance?.GetFieldValue("Name")) as string;
+            public string? Name
+            {
+                get => (Instance?.GetFieldValue("v0") ?? Instance?.GetFieldValue("Name")) as string;
+                set
+                {
+                    if (Instance != null && value != null)
+                    {
+                        Instance?.SetFieldValue("Name", value);
+                    }
+                }
+            }
 
             public int? ObjectId => Info?.Data.objectId;
 

--- a/RszTool/RszFile/RSZFile.cs
+++ b/RszTool/RszFile/RSZFile.cs
@@ -343,12 +343,6 @@ namespace RszTool
                         {
                             if (items[j] is int instanceId)
                             {
-                                if (instanceId >= instance.Index && field.IsTypeInferred)
-                                {
-                                    // TODO: may detect error, should roll back
-                                    field.type = RszFieldType.S32;
-                                    throw new RszRetryOpenException($"Detected {instance.RszClass.name}.{field.name} as Object before, but seems wrong");
-                                }
                                 items[j] = InstanceList[instanceId];
                                 InstanceUnflatten(InstanceList[instanceId]);
                             }
@@ -356,12 +350,6 @@ namespace RszTool
                     }
                     else if (instance.Values[i] is int instanceId)
                     {
-                        if (instanceId >= instance.Index && field.IsTypeInferred)
-                        {
-                            // TODO: may detect error, should roll back
-                            field.type = RszFieldType.S32;
-                            throw new RszRetryOpenException($"Detected {instance.RszClass.name}.{field.name} as Object before, but seems wrong");
-                        }
                         instance.Values[i] = InstanceList[instanceId];
                         InstanceUnflatten(InstanceList[instanceId]);
                     }

--- a/RszTool/RszFile/RSZFile.cs
+++ b/RszTool/RszFile/RSZFile.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using RszTool.Common;
 
 namespace RszTool
 {
@@ -31,7 +30,7 @@ namespace RszTool
         /// 基于InstanceInfoList生成的实例列表
         /// 一般第一个项是NULL，手动构建时需要注意
         /// </summary>
-        public List<RszInstance> InstanceList { get; } = new();
+        public RszInstanceList InstanceList { get; } = new();
         /// <summary>
         /// 基于ObjectTableList生成的实例列表，是对外公开的实例，
         /// InstanceList中包括里面依赖的成员实例或者实例数组的项

--- a/RszTool/RszFile/RszFileOption.cs
+++ b/RszTool/RszFile/RszFileOption.cs
@@ -7,6 +7,14 @@ namespace RszTool
         public RszParser RszParser { get; set; }
         public EnumParser EnumParser { get; set; }
 
+        public RszFileOption(GameName gameName, GameVersion version, RszParser rszParser, EnumParser enumParser)
+        {
+            GameName = gameName;
+            Version = version;
+            RszParser = rszParser;
+            EnumParser = enumParser;
+        }
+
         public RszFileOption(GameName gameName)
         {
             GameName = gameName;

--- a/RszTool/RszFile/RszInstance.cs
+++ b/RszTool/RszFile/RszInstance.cs
@@ -370,6 +370,7 @@ namespace RszTool
                 RszFieldType.Cone => typeof(via.Cone),
                 RszFieldType.Line => typeof(via.Line),
                 RszFieldType.LineSegment => typeof(via.LineSegment),
+                RszFieldType.OBB => typeof(via.OBB),
                 RszFieldType.Plane => typeof(via.Plane),
                 RszFieldType.PlaneXZ => typeof(via.PlaneXZ),
                 RszFieldType.Size => typeof(via.Size),

--- a/RszTool/RszFile/RszInstanceList.cs
+++ b/RszTool/RszFile/RszInstanceList.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections;
+
+namespace RszTool
+{
+    public class RszInstanceList : IEnumerable<RszInstance>, IList<RszInstance>
+    {
+        private readonly List<RszInstance> _list = new();
+        private readonly Dictionary<RszInstance, int> _indexMap = new();
+
+        public RszInstance this[int index]
+        {
+            get => _list[index];
+            set => throw new NotSupportedException();
+        }
+
+        RszInstance IList<RszInstance>.this[int index]
+        {
+            get => this[index];
+            set => this[index] = value;
+        }
+
+        public int Count => _list.Count;
+        public bool IsReadOnly => false;
+
+        public void Add(RszInstance item)
+        {
+            _list.Add(item);
+            _indexMap.Add(item, 0);
+        }
+
+        public void Clear()
+        {
+            _list.Clear();
+            _indexMap.Clear();
+        }
+
+        public int IndexOf(RszInstance item)
+        {
+            var result = -1;
+            if (_indexMap.TryGetValue(item, out var index))
+                result = index;
+            return result;
+        }
+
+        public bool Contains(RszInstance item) => _list.IndexOf(item) != -1;
+
+        public IEnumerator<RszInstance> GetEnumerator() => _list.GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void CopyTo(RszInstance[] array, int arrayIndex) => throw new NotImplementedException();
+        public void Insert(int index, RszInstance item) => throw new NotImplementedException();
+        public bool Remove(RszInstance item) => throw new NotImplementedException();
+        public void RemoveAt(int index) => throw new NotImplementedException();
+    }
+}

--- a/RszTool/RszFile/ScnFile.cs
+++ b/RszTool/RszFile/ScnFile.cs
@@ -167,7 +167,17 @@ namespace RszTool
                 set => parentRef = value != null ? new(value) : null;
             }
 
-            public string? Name => (Instance?.GetFieldValue("v0") ?? Instance?.GetFieldValue("Name")) as string;
+            public string? Name
+            {
+                get => (Instance?.GetFieldValue("v0") ?? Instance?.GetFieldValue("Name")) as string;
+                set
+                {
+                    if (Instance != null && value != null)
+                    {
+                        Instance?.SetFieldValue("Name", value);
+                    }
+                }
+            }
 
             public int? ObjectId => Info?.Data.objectId;
 

--- a/RszTool/RszParser.cs
+++ b/RszTool/RszParser.cs
@@ -27,6 +27,22 @@ namespace RszTool
 
         public Dictionary<uint, RszClass> ClassDict => classDict;
 
+        public RszParser(IEnumerable<RszClass> classes)
+        {
+            classDict = classes.ToDictionary(x => x.typeId);
+            classNameDict = classes.ToDictionary(x => x.name);
+            foreach (var c in classes)
+            {
+                foreach (var field in c.fields)
+                {
+                    if (field.type == RszFieldType.Data)
+                    {
+                        field.GuessDataType();
+                    }
+                }
+            }
+        }
+
         public RszParser(string jsonPath)
         {
             classDict = new();

--- a/RszTool/RszTool.csproj
+++ b/RszTool/RszTool.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="System.Memory" Version="4.5.5" />
-    <PackageReference Include="System.Text.Json" Version="8.0.0" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 


### PR DESCRIPTION
I don't think this should be merged. Rather I just wanted to make aware, a very inefficient part of the code, that caused saving a file to take a very long time, if many new game objects were added.

For context, I was programatically taking a file with many enemy spawns and duplicating them around 5 times and saving the file.
This caused an o(n²) search to occur with thousands of calls to `IndexOf` in `FixInstanceIndex`.

As a quick work around, I swapped the List<RszInstance> with a new class that wraps a list but also keeps a dictionary mapping the instances to their index in the list. This changed saving every area file from 30 second process down to near instant.

Ideally someone with better knowledge of the code should optimise the algorithm here so that it isn't doing so many searches through list which can have 300K items.